### PR TITLE
Compatibility with Minetest versions <5.6.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![ContentDB](https://content.minetest.net/packages/grorp/ggraffiti/shields/downloads/)](https://content.minetest.net/packages/grorp/ggraffiti/)
 
-This Minetest mod adds graffiti that lets you paint whatever you want on any node you want. It requires at least Minetest 5.6.0.
+This Minetest mod adds graffiti that lets you paint whatever you want on any node you want.
 
 <img src="./docpics/screenshot_1.png" style="width: 512px;" />
 

--- a/src/items.lua
+++ b/src/items.lua
@@ -162,6 +162,31 @@ local function lerp_factory(t)
     end
 end
 
+local function fast_new(x, y, z)
+	return setmetatable({x = x, y = y, z = z}, metatable)
+end
+
+-- Needed for compatibility with versions of minetest from before
+-- vector.combine() was added (5.6.0)
+local function vector_combine(a, b, func)
+	return fast_new(
+		func(a.x, b.x),
+		func(a.y, b.y),
+		func(a.z, b.z)
+	)
+end
+
+-- Needed for compatibility with versions of minetest from before
+-- vector.normalize() was added (5.6.0)
+function normalize(v)
+	local len = vector.length(v)
+	if len == 0 then
+		return fast_new(0, 0, 0)
+	else
+		return vector.divide(v, len)
+	end
+end
+
 local function spray_step(player)
     local player_name = player:get_player_name()
 
@@ -203,8 +228,8 @@ local function spray_step(player)
         else
             for step_n = 1, n_steps do
                 local lerp = lerp_factory(step_n / n_steps)
-                local pos = vector.combine(last.pos, now_pos, lerp)
-                local dir = vector.combine(last.dir, now_dir, lerp):normalize() -- "nlerp"
+                local pos = vector_combine(last.pos, now_pos, lerp)
+                local dir = normalize(vector_combine(last.dir, now_dir, lerp)) -- "nlerp"
 
                 shared.spraycast(player, pos, dir, spray_def)
             end


### PR DESCRIPTION
Hello,

Basically, the only thing that was preventing this mod from working on earlier versions of Minetest was the fact that it makes use of the functions `vector.normalize` and `vector.combine`. These were added in version 5.6.0. 

This pull request fixes this by simply copying over the missing functions over from [here](https://github.com/minetest/minetest/blob/042f7917e7aa264f91f85c1e073776a22922b2e5/builtin/common/vector.lua)

Closes #1.


Great job with this mod btw.
